### PR TITLE
Feature: cathode (CRT) display effect with trial-able variations

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -3,7 +3,11 @@
   import Input from './components/Input.svelte';
   import History from './components/History.svelte';
   import CommandSuggestionsRow from './components/CommandSuggestionsRow.svelte';
+  import Cathode from './components/Cathode.svelte';
   import { theme } from './stores/theme';
+  // Importing the store ensures the CRT effect's <html> classes are applied on
+  // first paint (restoring a persisted mode without a flash of the flat theme).
+  import './stores/cathode';
   
   let isPasswordMode = $state(false);
   let isProcessing = $state(false);
@@ -87,5 +91,7 @@
     {/if}
   </div>
 </main>
+
+<Cathode />
 
 

--- a/src/app.css
+++ b/src/app.css
@@ -86,3 +86,192 @@
   font-weight: bold;
   color: var(--theme-bright-cyan);
 }
+
+/* Dynamic cathode-mode list highlight (mirrors the theme list) */
+.cathode-name {
+  color: var(--theme-white);
+}
+
+.cathode-name.is-current {
+  font-weight: bold;
+  color: var(--theme-bright-cyan);
+}
+
+/* ==========================================================================
+   Cathode (CRT) display effect
+   --------------------------------------------------------------------------
+   The active variation is exposed as a class on <html> (e.g. `crt-vintage`)
+   plus a generic `crt-on` flag, both set by src/stores/cathode.ts.
+
+   Two things combine to sell the effect:
+     1. Per-character treatments applied directly to the terminal (`main`):
+        phosphor glow and RGB fringing, so they track each themed colour.
+     2. A fixed, pointer-events:none overlay of stacked layers (scanlines,
+        shadow mask, refresh sweep, flicker, vignette) that sits on top like
+        the curved glass of an old tube.
+   ========================================================================== */
+
+/* --- Terminal treatments (only when an effect is on) --------------------- */
+
+/* Phosphor + vintage: soft bloom that inherits each element's own colour. */
+:is(html.crt-phosphor, html.crt-vintage) main {
+  text-shadow: 0 0 1px currentColor, 0 0 6px currentColor;
+}
+
+/* Vintage additionally splits colour channels for a mistuned-tube look. */
+html.crt-vintage main {
+  text-shadow:
+    0.6px 0 0 rgba(255, 45, 90, 0.5),
+    -0.6px 0 0 rgba(60, 190, 255, 0.5),
+    0 0 6px currentColor;
+}
+
+/* Vintage nudges saturation/contrast up a touch to feel more analogue. */
+html.crt-vintage main {
+  filter: saturate(1.15) contrast(1.05);
+}
+
+/* --- Overlay scaffold ---------------------------------------------------- */
+
+.crt-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  pointer-events: none; /* never steal clicks/scroll from the terminal */
+  overflow: hidden;
+}
+
+html.crt-on .crt-overlay {
+  display: block;
+}
+
+.crt-layer {
+  position: absolute;
+  inset: 0;
+}
+
+/* Scanlines: faint horizontal gaps between "raster" lines. On by default for
+   every variation; individual modes tune the intensity below. */
+.crt-layer-scanlines {
+  background: repeating-linear-gradient(
+    to bottom,
+    rgba(0, 0, 0, 0) 0,
+    rgba(0, 0, 0, 0) 1.5px,
+    rgba(0, 0, 0, 0.28) 1.5px,
+    rgba(0, 0, 0, 0.28) 3px
+  );
+}
+
+html.crt-phosphor .crt-layer-scanlines {
+  opacity: 0.55; /* glow is the star here, so ease off the lines */
+}
+
+/* Shadow mask: vertical RGB triads. Reserved for the maximal vintage mode. */
+.crt-layer-mask {
+  display: none;
+  background: repeating-linear-gradient(
+    to right,
+    rgba(255, 0, 0, 0.06) 0,
+    rgba(0, 255, 0, 0.06) 1px,
+    rgba(0, 0, 255, 0.06) 2px,
+    rgba(0, 0, 0, 0) 3px
+  );
+}
+
+/* Refresh sweep: a soft bright band rolling slowly down the screen. */
+.crt-layer-sweep {
+  display: none;
+  top: 0;
+  height: 45vh;
+  background: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0) 0%,
+    rgba(255, 255, 255, 0.035) 50%,
+    rgba(255, 255, 255, 0) 100%
+  );
+  will-change: transform;
+  animation: crt-sweep 7s linear infinite;
+}
+
+/* Flicker: quick, small brightness jitter as if the beam can't hold steady. */
+.crt-layer-flicker {
+  display: none;
+  background: rgba(0, 0, 0, 0.12);
+  will-change: opacity;
+  animation: crt-flicker 0.13s steps(3, end) infinite;
+}
+
+/* Vignette: darkens the corners so the picture feels bowed into the tube. */
+.crt-layer-vignette {
+  background: radial-gradient(
+    ellipse at center,
+    rgba(0, 0, 0, 0) 58%,
+    rgba(0, 0, 0, 0.45) 100%
+  );
+}
+
+html.crt-vintage .crt-layer-vignette {
+  background: radial-gradient(
+    ellipse at center,
+    rgba(0, 0, 0, 0) 48%,
+    rgba(0, 0, 0, 0.68) 100%
+  );
+}
+
+/* --- Which layers each variation switches on ----------------------------- */
+
+/* scanlines: static lines + rolling refresh sweep + gentle vignette. */
+html.crt-scanlines .crt-layer-sweep {
+  display: block;
+}
+
+/* phosphor: glow (above) + softened scanlines + a subtle flicker. */
+html.crt-phosphor .crt-layer-flicker {
+  display: block;
+  background: rgba(0, 0, 0, 0.06);
+}
+
+/* vintage: everything at once. */
+html.crt-vintage .crt-layer-mask,
+html.crt-vintage .crt-layer-sweep,
+html.crt-vintage .crt-layer-flicker {
+  display: block;
+}
+
+@keyframes crt-sweep {
+  0% {
+    transform: translateY(-45vh);
+  }
+  100% {
+    transform: translateY(100vh);
+  }
+}
+
+@keyframes crt-flicker {
+  0% {
+    opacity: 0.10;
+  }
+  25% {
+    opacity: 0.32;
+  }
+  50% {
+    opacity: 0.06;
+  }
+  75% {
+    opacity: 0.24;
+  }
+  100% {
+    opacity: 0.12;
+  }
+}
+
+/* Respect users who prefer reduced motion: keep the static look, drop the
+   moving/animated layers that could be distracting or nauseating. */
+@media (prefers-reduced-motion: reduce) {
+  .crt-layer-sweep,
+  .crt-layer-flicker {
+    animation: none;
+    display: none !important;
+  }
+}

--- a/src/components/Cathode.svelte
+++ b/src/components/Cathode.svelte
@@ -1,0 +1,13 @@
+<!--
+  Decorative CRT ("cathode") overlay. Every layer is always present in the DOM;
+  which layers are visible and how they animate is controlled entirely by the
+  `crt-*` classes applied to <html> by the cathode store (see app.css).
+  The overlay is pointer-events:none so it never intercepts terminal input.
+-->
+<div class="crt-overlay" aria-hidden="true">
+  <div class="crt-layer crt-layer-scanlines"></div>
+  <div class="crt-layer crt-layer-mask"></div>
+  <div class="crt-layer crt-layer-sweep"></div>
+  <div class="crt-layer crt-layer-flicker"></div>
+  <div class="crt-layer crt-layer-vignette"></div>
+</div>

--- a/src/components/Input.svelte
+++ b/src/components/Input.svelte
@@ -9,6 +9,7 @@
   import { track } from "../utils/tracking";
   import { get } from "svelte/store";
   import themes from "../../themes.json";
+  import { cathodeModes } from "../stores/cathode";
 
   // Use $props() to declare props with $bindable()
   let {
@@ -458,6 +459,64 @@
         } else if (matchingThemes.length > 1) {
           // Find common prefix
           const commonPrefix = matchingThemes.reduce((prefix, name) => {
+            let i = 0;
+            while (
+              i < prefix.length &&
+              i < name.length &&
+              prefix[i] === name[i]
+            ) {
+              i++;
+            }
+            return prefix.substring(0, i);
+          });
+          if (commonPrefix.length > currentArg.length) {
+            parts[parts.length - 1] = commonPrefix;
+            command = parts.join(" ");
+          }
+        }
+      } else if (commandName === "cathode" && parts.length === 2) {
+        // Complete cathode subcommands (ls, set, off)
+        const cathodeSubcommands = ["ls", "set", "off"];
+        const matchingSubcommands = cathodeSubcommands.filter((sub) =>
+          sub.startsWith(currentArg.toLowerCase()),
+        );
+
+        if (matchingSubcommands.length === 1) {
+          command = `cathode ${matchingSubcommands[0]}`;
+        } else if (matchingSubcommands.length > 1) {
+          const commonPrefix = matchingSubcommands.reduce((prefix, sub) => {
+            let i = 0;
+            while (
+              i < prefix.length &&
+              i < sub.length &&
+              prefix[i] === sub[i]
+            ) {
+              i++;
+            }
+            return prefix.substring(0, i);
+          });
+          if (commonPrefix.length > currentArg.length) {
+            command = `cathode ${commonPrefix}`;
+          }
+        }
+      } else if (
+        commandName === "cathode" &&
+        parts.length === 3 &&
+        parts[1] === "set"
+      ) {
+        // Complete cathode variation names for 'cathode set'
+        const variations: string[] = cathodeModes.filter(
+          (mode) => mode !== "off",
+        );
+        const matchingVariations = variations.filter((name) =>
+          name.startsWith(currentArg.toLowerCase()),
+        );
+
+        if (matchingVariations.length === 1) {
+          parts[parts.length - 1] = matchingVariations[0];
+          command = parts.join(" ");
+        } else if (matchingVariations.length > 1) {
+          const commonPrefix = matchingVariations.reduce((prefix, name) => {
             let i = 0;
             while (
               i < prefix.length &&

--- a/src/stores/cathode.ts
+++ b/src/stores/cathode.ts
@@ -1,0 +1,69 @@
+import { writable } from 'svelte/store';
+
+// A "cathode" effect emulates the look of an old CRT (cathode ray tube) display.
+// Each mode is a distinct variation the user can trial on the terminal.
+export const cathodeModes = ['off', 'scanlines', 'phosphor', 'vintage'] as const;
+export type CathodeMode = (typeof cathodeModes)[number];
+
+export interface CathodeModeInfo {
+  name: CathodeMode;
+  summary: string;
+}
+
+// Ordered list used by the `cathode` command for listing/help output.
+export const cathodeModeInfo: CathodeModeInfo[] = [
+  { name: 'off', summary: 'No effect. A clean, modern flat display.' },
+  { name: 'scanlines', summary: 'Subtle horizontal scanlines with a slow refresh sweep.' },
+  { name: 'phosphor', summary: 'Glowing phosphor text, scanlines and a gentle flicker.' },
+  { name: 'vintage', summary: 'The full retro set: glow, flicker, RGB fringing and a heavy vignette.' },
+];
+
+const STORAGE_KEY = 'cathode';
+const CLASS_PREFIX = 'crt-';
+
+function isCathodeMode(value: string | null): value is CathodeMode {
+  return value !== null && (cathodeModes as readonly string[]).includes(value);
+}
+
+// Reflect the active mode onto <html> so global CSS can style the terminal
+// (text glow, curvature) without every component needing to know the mode.
+// `crt-on` is a convenience flag so selectors can target "any effect" cheaply.
+function applyDocumentMode(mode: CathodeMode) {
+  if (typeof document === 'undefined') return;
+  const root = document.documentElement;
+  cathodeModes.forEach((m) => root.classList.remove(`${CLASS_PREFIX}${m}`));
+  root.classList.toggle('crt-on', mode !== 'off');
+  if (mode !== 'off') {
+    root.classList.add(`${CLASS_PREFIX}${mode}`);
+  }
+}
+
+// Keep any previously printed "cathode ls" output in sync with the active mode.
+function updateCathodeListHighlight(mode: CathodeMode) {
+  if (typeof document === 'undefined') return;
+  const nodes = document.querySelectorAll<HTMLElement>('.cathode-name');
+  nodes.forEach((el) => {
+    const name = el.getAttribute('data-cathode-name');
+    el.classList.toggle('is-current', name === mode);
+  });
+}
+
+const initialMode: CathodeMode =
+  typeof localStorage !== 'undefined' && isCathodeMode(localStorage.getItem(STORAGE_KEY))
+    ? (localStorage.getItem(STORAGE_KEY) as CathodeMode)
+    : 'off';
+
+if (typeof document !== 'undefined') {
+  applyDocumentMode(initialMode);
+  updateCathodeListHighlight(initialMode);
+}
+
+export const cathode = writable<CathodeMode>(initialMode);
+
+cathode.subscribe((mode) => {
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem(STORAGE_KEY, mode);
+  }
+  applyDocumentMode(mode);
+  updateCathodeListHighlight(mode);
+});

--- a/src/utils/commandSuggestions.ts
+++ b/src/utils/commandSuggestions.ts
@@ -1,7 +1,11 @@
 import themes from '../../themes.json';
+import { cathodeModes } from '../stores/cathode';
 import { getCurrentDirectory } from './virtualFileSystem';
 
 const themeNames = themes.map((t) => t.name);
+// `off` is offered via its own `cathode off` subcommand, so the `set` list
+// only surfaces the actual visual variations.
+const cathodeVariations = cathodeModes.filter((m) => m !== 'off');
 const weatherExamples = ['weather Gadigal', 'weather Oslo', 'weather Aotearoa'];
 const curlExamples = [
   'curl explainshell.com',
@@ -42,6 +46,10 @@ export function getCommandSuggestions(input: string, commandNames: string[]): st
   if (parts.length === 1) {
     if (command === 'theme') {
       return ['theme ls', 'theme set'];
+    }
+
+    if (command === 'cathode') {
+      return ['cathode ls', 'cathode set', 'cathode off'];
     }
 
     if (command === 'weather') {
@@ -190,6 +198,36 @@ export function getCommandSuggestions(input: string, commandNames: string[]): st
       return themeNames
         .filter((name) => name.toLowerCase().startsWith(prefixLower))
         .map((name) => `theme set ${name}`);
+    }
+  }
+
+  if (command === 'cathode') {
+    const subcommands = ['ls', 'set', 'off'];
+    const subcommand = parts[1] ?? '';
+
+    if (parts.length === 2) {
+      if (subcommand === 'set') {
+        return cathodeVariations.map((name) => `cathode set ${name}`);
+      }
+
+      if (subcommands.includes(subcommand)) {
+        return [];
+      }
+
+      return subcommands.filter((s) => s.startsWith(subcommand)).map((s) => `cathode ${s}`);
+    }
+
+    if (parts.length >= 3 && parts[1] === 'set') {
+      const variationPrefix = parts[2] ?? '';
+      const prefixLower = variationPrefix.toLowerCase();
+
+      if (!variationPrefix && endsWithSpace) {
+        return cathodeVariations.map((name) => `cathode set ${name}`);
+      }
+
+      return cathodeVariations
+        .filter((name) => name.toLowerCase().startsWith(prefixLower))
+        .map((name) => `cathode set ${name}`);
     }
   }
 

--- a/src/utils/commands.ts
+++ b/src/utils/commands.ts
@@ -6,6 +6,7 @@ import { fileSystemCommands } from './commands/fileSystem';
 import { networkCommands } from './commands/network';
 import { qrCommands } from './commands/qr';
 import { theme } from '../stores/theme';
+import { cathode, cathodeModes, cathodeModeInfo, type CathodeMode } from '../stores/cathode';
 import { get } from 'svelte/store';
 import { virtualFileSystem, currentPath, type VirtualFile, resolvePath } from './virtualFileSystem';
 import { commandHelp, commandDescriptions } from './helpTexts';
@@ -190,6 +191,80 @@ const projectCommands = {
       }
 
       default: {
+        return usage;
+      }
+    }
+  },
+  cathode: (args: string[]) => {
+    const usage = `<span style="color: var(--theme-cyan); font-weight: bold;">cathode</span> - Trial a retro CRT (cathode ray tube) display effect
+<span style="color: var(--theme-yellow); font-weight: bold;">Usage:</span> cathode <span style="color: var(--theme-green);">[args]</span>.
+  <span style="color: var(--theme-green);">args:</span>
+    ls: list all cathode variations
+    set: set the effect to [variation]
+    off: turn the effect off
+
+<span style="color: var(--theme-red); font-weight: bold;">Examples:</span>
+  cathode ls
+  cathode set vintage
+  cathode off`;
+
+    const applyMode = (mode: CathodeMode) => {
+      cathode.set(mode);
+      if (mode === 'off') {
+        return 'Cathode effect turned off.';
+      }
+      return `Cathode effect set to ${mode}. Try 'cathode ls' to compare the variations.`;
+    };
+
+    if (args.length === 0) {
+      return usage;
+    }
+
+    switch (args[0]) {
+      case 'ls': {
+        const current = get(cathode);
+        const nameWidth = Math.max(...cathodeModes.map((m) => m.length));
+
+        const rows = cathodeModeInfo
+          .map(({ name, summary }) => {
+            const isCurrent = name === current;
+            const padding = ' '.repeat(nameWidth - name.length + 2);
+            const label = `<span class="cathode-name${isCurrent ? ' is-current' : ''}" data-cathode-name="${name}">${name}</span>`;
+            return `  ${label}${padding}<span style="color: var(--theme-white);">${summary}</span>`;
+          })
+          .join('\n');
+
+        return `<span style="color: var(--theme-cyan);">Cathode variations (current highlighted):</span>
+${rows}
+
+<span style="color: var(--theme-yellow);">Trial one with:</span> cathode set <span style="color: var(--theme-green);">[variation]</span>`;
+      }
+
+      case 'set': {
+        if (args.length !== 2) {
+          return usage;
+        }
+
+        const requested = args[1].toLowerCase();
+        const match = cathodeModes.find((m) => m === requested);
+        if (!match) {
+          return `Cathode variation '${args[1]}' not found. Try 'cathode ls' to see all available variations.`;
+        }
+
+        return applyMode(match);
+      }
+
+      case 'off': {
+        return applyMode('off');
+      }
+
+      default: {
+        // Friendly shortcut: `cathode vintage` behaves like `cathode set vintage`.
+        const requested = args[0].toLowerCase();
+        const match = cathodeModes.find((m) => m === requested);
+        if (match) {
+          return applyMode(match);
+        }
         return usage;
       }
     }

--- a/src/utils/helpTexts.ts
+++ b/src/utils/helpTexts.ts
@@ -56,6 +56,17 @@ stock MSFT`,
 <span style="color: var(--theme-red); font-weight: bold;">Examples:</span>
   theme ls
   theme set swamphen`,
+  cathode: `<span style="color: var(--theme-cyan); font-weight: bold;">cathode</span> - Trial a retro CRT (cathode ray tube) display effect
+<span style="color: var(--theme-yellow); font-weight: bold;">Usage:</span> cathode <span style="color: var(--theme-green);">[args]</span>.
+  <span style="color: var(--theme-green);">args:</span>
+    ls: list all cathode variations
+    set: set the effect to [variation]
+    off: turn the effect off
+
+<span style="color: var(--theme-red); font-weight: bold;">Examples:</span>
+  cathode ls
+  cathode set phosphor
+  cathode off`,
   repo: `<span style="color: var(--theme-cyan); font-weight: bold;">repo</span> : Opens the project's GitHub repository in a new tab.<br><span style="color: var(--theme-yellow); font-weight: bold;">Usage:</span> repo`,
   email: `<span style="color: var(--theme-cyan); font-weight: bold;">email</span> : Opens the default email client to send an email to the developer.<br><span style="color: var(--theme-yellow); font-weight: bold;">Usage:</span> email`,
   banner: `<span style="color: var(--theme-cyan); font-weight: bold;">banner</span> : Shows the terminal welcome banner with ASCII art and version information.<br><span style="color: var(--theme-yellow); font-weight: bold;">Usage:</span> banner`,
@@ -90,6 +101,7 @@ export const commandDescriptions = {
   'curl': 'HTTP request',
   'stock': 'Stock data',
   'theme': 'Change theme',
+  'cathode': 'Trial CRT effect',
   'repo': 'Open repository',
   'email': 'Open mail client',
   'banner': 'Show banner',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Overview

Adds a `cathode` command so you can **trial a few variations of a retro CRT (cathode ray tube) effect** on the terminal and keep whichever you like. The active variation persists across reloads (via `localStorage`), just like the theme.

## Usage

```
cathode              # show usage
cathode ls           # list variations (current one highlighted)
cathode set vintage  # apply a variation
cathode vintage      # shortcut for `cathode set vintage`
cathode off          # back to the flat, modern look
```

It's fully wired into the existing UX: `help` grid entry, `--help` text, live autocomplete suggestions and Tab completion — all following the same patterns as the `theme` command.

## The variations

| Variation | Look |
|---|---|
| `off` | No effect. Clean, modern flat display (default). |
| `scanlines` | Subtle horizontal scanlines + a slow refresh sweep + gentle vignette. |
| `phosphor` | Colour-tracking phosphor glow + softened scanlines + a gentle flicker. |
| `vintage` | The full set: glow, shadow mask, flicker, RGB fringing and a heavy vignette. |

## Previews

Default (swamphen) theme — `off` vs `scanlines` vs `phosphor` vs `vintage`:

[cathode off](https://cursor.com/agents/bc-fd76ee2b-2654-47c4-b677-30e883da8f69/artifacts?path=%2Fworkspace%2F.preview-shots%2Foff.png)
[cathode scanlines](https://cursor.com/agents/bc-fd76ee2b-2654-47c4-b677-30e883da8f69/artifacts?path=%2Fworkspace%2F.preview-shots%2Fscanlines.png)
[cathode phosphor](https://cursor.com/agents/bc-fd76ee2b-2654-47c4-b677-30e883da8f69/artifacts?path=%2Fworkspace%2F.preview-shots%2Fphosphor.png)
[cathode vintage](https://cursor.com/agents/bc-fd76ee2b-2654-47c4-b677-30e883da8f69/artifacts?path=%2Fworkspace%2F.preview-shots%2Fvintage.png)

The classic green-phosphor look really shows the effect off — `phosphor` and `vintage` on the `treefrog` theme (note the visible shadow-mask grid on vintage):

[phosphor on treefrog theme](https://cursor.com/agents/bc-fd76ee2b-2654-47c4-b677-30e883da8f69/artifacts?path=%2Fworkspace%2F.preview-shots%2Fphosphor-treefrog.png)
[vintage on treefrog theme](https://cursor.com/agents/bc-fd76ee2b-2654-47c4-b677-30e883da8f69/artifacts?path=%2Fworkspace%2F.preview-shots%2Fvintage-treefrog.png)

`cathode ls` output (current variation highlighted; the highlight of any earlier listing updates live when the mode changes, mirroring `theme ls`):

[cathode ls listing](https://cursor.com/agents/bc-fd76ee2b-2654-47c4-b677-30e883da8f69/artifacts?path=%2Fworkspace%2F.preview-shots%2Fcathode-ls.png)

## Implementation

- **`src/stores/cathode.ts`** — a `writable` store for the active mode with `localStorage` persistence. It reflects the mode onto `<html>` as `crt-<mode>` / `crt-on` classes and keeps any printed `cathode ls` highlight in sync.
- **`src/components/Cathode.svelte`** — a `pointer-events: none`, fixed overlay of stacked layers (scanlines, shadow mask, refresh sweep, flicker, vignette). It never intercepts terminal input.
- **`src/app.css`** — the CRT styling. Per-character treatments (glow, RGB fringing) are applied to the terminal `main` using `currentColor`, so they track each themed colour; the overlay layers are toggled/tuned per mode. Animated layers are disabled under `prefers-reduced-motion`.
- **`src/utils/commands.ts`**, **`helpTexts.ts`**, **`commandSuggestions.ts`**, **`components/Input.svelte`** — the `cathode` command, help/description, suggestions and Tab completion.

## Testing

- `npm run check` — no new type errors (2 pre-existing errors in `theme.ts` remain untouched).
- `npm run build` — succeeds.
- Verified each variation in a headless Chrome against the production preview build (screenshots above).

> Note: the preview images are captured artifacts, not committed to the repo. `package.json` / `package-lock.json` are unchanged.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fd76ee2b-2654-47c4-b677-30e883da8f69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fd76ee2b-2654-47c4-b677-30e883da8f69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

